### PR TITLE
Fix resources left behind on deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix resources left behind on deletion
+- Avoid distracting error logs for expected situations
+
 ## [0.4.4] - 2022-11-29
 
 ### Fixed

--- a/controllers/awsmachinepool_controller.go
+++ b/controllers/awsmachinepool_controller.go
@@ -22,8 +22,10 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	expcapa "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -50,7 +52,9 @@ func (r *AWSMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	awsMachinePool := &expcapa.AWSMachinePool{}
 	if err := r.Get(ctx, req.NamespacedName, awsMachinePool); err != nil {
-		logger.Error(err, "AWSMachinePool does not exist")
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, err
 	}
 	// check if CR got CAPI watch-filter label
@@ -65,7 +69,7 @@ func (r *AWSMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	logger = logger.WithValues("cluster", clusterName)
 
 	if awsMachinePool.Spec.AWSLaunchTemplate.IamInstanceProfile == "" {
-		logger.Info("AWSMachinePool has empty .Spec.AWSLaunchTemplate.IamInstanceProfile, not creating IAM role")
+		logger.Info("AWSMachinePool has empty .Spec.AWSLaunchTemplate.IamInstanceProfile, not reconciling IAM role")
 		return ctrl.Result{}, nil
 	}
 
@@ -127,33 +131,49 @@ func (r *AWSMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				logger.Error(err, "failed to get awsCluster")
 				return ctrl.Result{}, err
 			}
-			controllerutil.RemoveFinalizer(awsCluster, key.FinalizerName(iam.NodesRole))
-			err = r.Update(ctx, awsCluster)
-			if err != nil {
-				logger.Error(err, "failed to remove finalizer on AWSCluster")
-				return ctrl.Result{}, err
+			if controllerutil.ContainsFinalizer(awsCluster, key.FinalizerName(iam.NodesRole)) {
+				patchHelper, err := patch.NewHelper(awsCluster, r.Client)
+				if err != nil {
+					return ctrl.Result{}, err
+				}
+				controllerutil.RemoveFinalizer(awsCluster, key.FinalizerName(iam.NodesRole))
+				err = patchHelper.Patch(ctx, awsCluster)
+				if err != nil {
+					logger.Error(err, "failed to remove finalizer on AWSCluster")
+					return ctrl.Result{}, err
+				}
+				logger.Info("successfully removed finalizer from AWSCluster", "finalizer_name", iam.NodesRole)
 			}
 		}
 
 		// remove finalizer from AWSMachinePool
-		controllerutil.RemoveFinalizer(awsMachinePool, key.FinalizerName(iam.NodesRole))
-		err = r.Update(ctx, awsMachinePool)
-		if err != nil {
-			logger.Error(err, "failed to remove finalizer from AWSMachinePool")
-			return ctrl.Result{}, err
+		if controllerutil.ContainsFinalizer(awsMachinePool, key.FinalizerName(iam.NodesRole)) {
+			patchHelper, err := patch.NewHelper(awsMachinePool, r.Client)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			controllerutil.RemoveFinalizer(awsMachinePool, key.FinalizerName(iam.NodesRole))
+			err = patchHelper.Patch(ctx, awsMachinePool)
+			if err != nil {
+				logger.Error(err, "failed to remove finalizer from AWSMachinePool")
+				return ctrl.Result{}, err
+			}
+			logger.Info("successfully removed finalizer from AWSMachinePool", "finalizer_name", iam.NodesRole)
 		}
 	} else {
-		err = iamService.ReconcileRole()
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-
 		// add finalizer to AWSMachinePool
-		controllerutil.AddFinalizer(awsMachinePool, key.FinalizerName(iam.NodesRole))
-		err = r.Update(ctx, awsMachinePool)
-		if err != nil {
-			logger.Error(err, "failed to add finalizer on AWSMachinePool")
-			return ctrl.Result{}, err
+		if !controllerutil.ContainsFinalizer(awsMachinePool, key.FinalizerName(iam.NodesRole)) {
+			patchHelper, err := patch.NewHelper(awsMachinePool, r.Client)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			controllerutil.AddFinalizer(awsMachinePool, key.FinalizerName(iam.NodesRole))
+			err = patchHelper.Patch(ctx, awsMachinePool)
+			if err != nil {
+				logger.Error(err, "failed to add finalizer on AWSMachinePool")
+				return ctrl.Result{}, err
+			}
+			logger.Info("successfully added finalizer to AWSMachinePool", "finalizer_name", iam.NodesRole)
 		}
 
 		// add finalizer to AWSCluster
@@ -163,12 +183,24 @@ func (r *AWSMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				logger.Error(err, "failed to get awsCluster")
 				return ctrl.Result{}, err
 			}
-			controllerutil.AddFinalizer(awsCluster, key.FinalizerName(iam.NodesRole))
-			err = r.Update(ctx, awsCluster)
-			if err != nil {
-				logger.Error(err, "failed to add finalizer on AWSCluster")
-				return ctrl.Result{}, err
+			if !controllerutil.ContainsFinalizer(awsCluster, key.FinalizerName(iam.NodesRole)) {
+				patchHelper, err := patch.NewHelper(awsCluster, r.Client)
+				if err != nil {
+					return ctrl.Result{}, err
+				}
+				controllerutil.AddFinalizer(awsCluster, key.FinalizerName(iam.NodesRole))
+				err = patchHelper.Patch(ctx, awsCluster)
+				if err != nil {
+					logger.Error(err, "failed to add finalizer on AWSCluster")
+					return ctrl.Result{}, err
+				}
+				logger.Info("successfully added finalizer to AWSCluster", "finalizer_name", iam.NodesRole)
 			}
+		}
+
+		err = iamService.ReconcileRole()
+		if err != nil {
+			return ctrl.Result{}, err
 		}
 	}
 

--- a/controllers/awsmachinetemplate_controller.go
+++ b/controllers/awsmachinetemplate_controller.go
@@ -22,8 +22,10 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	capa "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -56,7 +58,9 @@ func (r *AWSMachineTemplateReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	awsMachineTemplate := &capa.AWSMachineTemplate{}
 	if err := r.Get(ctx, req.NamespacedName, awsMachineTemplate); err != nil {
-		logger.Error(err, "AWSMachineTemplate does not exist")
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, err
 	}
 	// check if CR got CAPI watch-filter label
@@ -158,22 +162,74 @@ func (r *AWSMachineTemplateReconciler) Reconcile(ctx context.Context, req ctrl.R
 				logger.Error(err, "failed to get awsCluster")
 				return ctrl.Result{}, err
 			}
-			controllerutil.RemoveFinalizer(awsCluster, key.FinalizerName(iam.ControlPlaneRole))
-			err = r.Update(ctx, awsCluster)
-			if err != nil {
-				logger.Error(err, "failed to remove finalizer on AWSCluster")
-				return ctrl.Result{}, err
+
+			if controllerutil.ContainsFinalizer(awsCluster, key.FinalizerName(iam.ControlPlaneRole)) {
+				patchHelper, err := patch.NewHelper(awsCluster, r.Client)
+				if err != nil {
+					return ctrl.Result{}, err
+				}
+				controllerutil.RemoveFinalizer(awsCluster, key.FinalizerName(iam.ControlPlaneRole))
+				err = patchHelper.Patch(ctx, awsCluster)
+				if err != nil {
+					logger.Error(err, "failed to remove finalizer on AWSCluster")
+					return ctrl.Result{}, err
+				}
+				logger.Info("successfully removed finalizer from AWSCluster", "finalizer_name", iam.ControlPlaneRole)
 			}
 		}
 
 		// remove finalizer from AWSMachineTemplate
-		controllerutil.RemoveFinalizer(awsMachineTemplate, key.FinalizerName(iam.ControlPlaneRole))
-		err = r.Update(ctx, awsMachineTemplate)
-		if err != nil {
-			logger.Error(err, "failed to remove finalizer from AWSMachineTemplate")
-			return ctrl.Result{}, err
+		if controllerutil.ContainsFinalizer(awsMachineTemplate, key.FinalizerName(iam.ControlPlaneRole)) {
+			patchHelper, err := patch.NewHelper(awsMachineTemplate, r.Client)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			controllerutil.RemoveFinalizer(awsMachineTemplate, key.FinalizerName(iam.ControlPlaneRole))
+			err = patchHelper.Patch(ctx, awsMachineTemplate)
+			if err != nil {
+				logger.Error(err, "failed to remove finalizer from AWSMachineTemplate")
+				return ctrl.Result{}, err
+			}
+			logger.Info("successfully removed finalizer from AWSMachineTemplate", "finalizer_name", iam.ControlPlaneRole)
 		}
 	} else {
+		// add finalizer to AWSMachineTemplate
+		if !controllerutil.ContainsFinalizer(awsMachineTemplate, key.FinalizerName(iam.ControlPlaneRole)) {
+			patchHelper, err := patch.NewHelper(awsMachineTemplate, r.Client)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			controllerutil.AddFinalizer(awsMachineTemplate, key.FinalizerName(iam.ControlPlaneRole))
+			err = patchHelper.Patch(ctx, awsMachineTemplate)
+			if err != nil {
+				logger.Error(err, "failed to add finalizer on AWSMachineTemplate")
+				return ctrl.Result{}, err
+			}
+			logger.Info("successfully added finalizer to AWSMachineTemplate", "finalizer_name", iam.ControlPlaneRole)
+		}
+
+		// add finalizer to AWSCluster
+		{
+			awsCluster, err := key.GetAWSClusterByName(ctx, r.Client, clusterName)
+			if err != nil {
+				logger.Error(err, "failed to get awsCluster")
+				return ctrl.Result{}, err
+			}
+			if !controllerutil.ContainsFinalizer(awsCluster, key.FinalizerName(iam.ControlPlaneRole)) {
+				patchHelper, err := patch.NewHelper(awsCluster, r.Client)
+				if err != nil {
+					return ctrl.Result{}, err
+				}
+				controllerutil.AddFinalizer(awsCluster, key.FinalizerName(iam.ControlPlaneRole))
+				err = patchHelper.Patch(ctx, awsCluster)
+				if err != nil {
+					logger.Error(err, "failed to add finalizer on AWSCluster")
+					return ctrl.Result{}, err
+				}
+				logger.Info("successfully added finalizer to AWSCluster", "finalizer_name", iam.ControlPlaneRole)
+			}
+		}
+
 		err = iamService.ReconcileRole()
 		if err != nil {
 			return ctrl.Result{}, err
@@ -191,28 +247,6 @@ func (r *AWSMachineTemplateReconciler) Reconcile(ctx context.Context, req ctrl.R
 				if err != nil {
 					return ctrl.Result{}, err
 				}
-			}
-		}
-		// add finalizer to AWSMachineTemplate
-		controllerutil.AddFinalizer(awsMachineTemplate, key.FinalizerName(iam.ControlPlaneRole))
-		err = r.Update(ctx, awsMachineTemplate)
-		if err != nil {
-			logger.Error(err, "failed to add finalizer on AWSMachineTemplate")
-			return ctrl.Result{}, err
-		}
-
-		// add finalizer to AWSCluster
-		{
-			awsCluster, err := key.GetAWSClusterByName(ctx, r.Client, clusterName)
-			if err != nil {
-				logger.Error(err, "failed to get awsCluster")
-				return ctrl.Result{}, err
-			}
-			controllerutil.AddFinalizer(awsCluster, key.FinalizerName(iam.ControlPlaneRole))
-			err = r.Update(ctx, awsCluster)
-			if err != nil {
-				logger.Error(err, "failed to add finalizer on AWSCluster")
-				return ctrl.Result{}, err
 			}
 		}
 	}

--- a/controllers/capa_utils.go
+++ b/controllers/capa_utils.go
@@ -20,7 +20,7 @@ func isRoleUsedElsewhere(ctx context.Context, ctrlClient client.Client, roleName
 		return false, err
 	}
 	for _, mt := range awsMachineTemplates.Items {
-		if mt.DeletionTimestamp != nil && mt.Spec.Template.Spec.IAMInstanceProfile == roleName {
+		if mt.DeletionTimestamp == nil && mt.Spec.Template.Spec.IAMInstanceProfile == roleName {
 			return true, err
 		}
 	}
@@ -33,8 +33,8 @@ func isRoleUsedElsewhere(ctx context.Context, ctrlClient client.Client, roleName
 	if err != nil {
 		return false, err
 	}
-	for _, mt := range awsMachinePools.Items {
-		if mt.DeletionTimestamp != nil && mt.Spec.AWSLaunchTemplate.IamInstanceProfile == roleName {
+	for _, mp := range awsMachinePools.Items {
+		if mp.DeletionTimestamp == nil && mp.Spec.AWSLaunchTemplate.IamInstanceProfile == roleName {
 			return true, err
 		}
 	}

--- a/pkg/iam/iam.go
+++ b/pkg/iam/iam.go
@@ -12,8 +12,8 @@ import (
 
 const (
 	BastionRole      = "bastion"
-	ControlPlaneRole = "control-plane"
-	NodesRole        = "nodes"
+	ControlPlaneRole = "control-plane" // also used as part of finalizer name
+	NodesRole        = "nodes"         // also used as part of finalizer name
 	Route53Role      = "route53-role"
 	KIAMRole         = "kiam-role"
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1829

The "is role still used or can I delete it?" function did the opposite of what it should, resulting in nothing being deleted. Also, we added/removed finalizers at the wrong place and used Update instead of Patch. There also lots of unhelpful error messages for expected situations – e.g. when the object has fully gone away. All those are fixed.

See other minor changes in commit message.

Confirmed working by testing on `golem`.