### PR TITLE
create-roles-before-irsa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fetch IRSA secret resource just right befire creating IRSA role to avoid locking node role creation for control plane and workers.
+
 ## [0.8.0] - 2023-05-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2023-05-08
+
 ### Fixed
 
 - Add `control-plane` finalizer to IRSA cloudfront secret.
@@ -104,7 +106,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement `AWSMachineTemplate` reconciler.
 - Implement `AWSMachinePool` reconciler.
 
-[Unreleased]: https://github.com/giantswarm/capa-iam-operator/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/giantswarm/capa-iam-operator/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/giantswarm/capa-iam-operator/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/giantswarm/capa-iam-operator/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/giantswarm/capa-iam-operator/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/giantswarm/capa-iam-operator/compare/v0.5.0...v0.5.1

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -147,8 +147,6 @@ func (r *SecretReconciler) reconcileNormal(ctx context.Context, logger logr.Logg
 			MainRoleName:              "-",
 			RoleType:                  iam.IRSARole,
 			Log:                       logger,
-			AccountID:                 accountID,
-			CloudFrontDomain:          domain,
 			IAMClientAndRegionFactory: r.IAMClientAndRegionFactory,
 		}
 		iamService, err = iam.New(c)
@@ -157,7 +155,7 @@ func (r *SecretReconciler) reconcileNormal(ctx context.Context, logger logr.Logg
 		}
 	}
 
-	err = iamService.ReconcileRolesForIRSA()
+	err = iamService.ReconcileRolesForIRSA(accountID, domain)
 	if err != nil {
 		logger.Error(err, "Unable to reconcile role")
 		return ctrl.Result{}, err


### PR DESCRIPTION
fetch IRSA secret only  right before creating a role for IRSA to unblock node role creation for the control plane and for the workers, that will unblock  flatcar as it needs node roles for the S3 bucket

towards https://github.com/giantswarm/roadmap/issues/996