### PR TITLE
Use `cert-manager-app` as service account name for Cert Manager (chan…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Use `cert-manager-app` as service account name for Cert Manager (changed in recent version of cert-manager app).
+- Use `cert-manager-app` as service account name for Cert Manager (changed in recent version of cert-manager-app).
 
 ## [0.15.0] - 2024-01-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use `cert-manager-app` as service account name for Cert Manager (changed in recent version of cert-manager app).
+
 ## [0.15.0] - 2024-01-10
 
 ### Changed

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -22,7 +22,7 @@ var certManagerRoleInfo = RoleInfo{
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
-          "irsa.test.gaws.gigantic.io:sub": "system:serviceaccount:kube-system:cert-manager-controller"
+          "irsa.test.gaws.gigantic.io:sub": "system:serviceaccount:kube-system:cert-manager-app"
         }
       }
     }

--- a/pkg/iam/iam.go
+++ b/pkg/iam/iam.go
@@ -656,7 +656,7 @@ func policyName(role string, clusterID string) string {
 
 func getServiceAccount(role string) (string, error) {
 	if role == CertManagerRole {
-		return "cert-manager-controller", nil
+		return "cert-manager-app", nil
 	} else if role == IRSARole {
 		return "external-dns", nil
 	} else if role == Route53Role {


### PR DESCRIPTION
…ged in recent version of cert-manager app).

towards: https://github.com/giantswarm/giantswarm/issues/30058