### PR TITLE
Use `/aws/` as `AWS_SHARED_CREDENTIALS_FILE` to overcome changes in b…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use `cert-manager-app` as service account name for Cert Manager (changed in recent version of cert-manager-app).
 
+### Fixed
+
+- Use `/aws/` as `AWS_SHARED_CREDENTIALS_FILE` to overcome changes in base images.
+
 ## [0.15.0] - 2024-01-10
 
 ### Changed

--- a/helm/capa-iam-operator/templates/deployment.yaml
+++ b/helm/capa-iam-operator/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
         image: "{{ .Values.registry.domain }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         env:
         - name: AWS_SHARED_CREDENTIALS_FILE
-          value: /home/.aws/credentials
+          value: /aws/credentials
         command:
         - /manager
         args:
@@ -70,7 +70,7 @@ spec:
             cpu: 200m
             memory: 128Mi
         volumeMounts:
-        - mountPath: /home/.aws
+        - mountPath: /aws
           name: credentials
       terminationGracePeriodSeconds: 10
       volumes:


### PR DESCRIPTION
…ase images.

newer builds failed to authenticate to AWS. I suspect a change in the base images led to this behaviour change.