### PR TITLE
Use a more relaxed trust identity policy for `Route53Manager` IAM rol…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use a more relaxed trust identity policy for `Route53Manager` IAM role to allow running multiple external-dns instances in the same cluster.
+
 ## [0.19.0] - 2024-03-19
 
 ### Changed

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -73,7 +73,7 @@ var externalDnsRoleInfo = RoleInfo{
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
-          "irsa.test.gaws.gigantic.io:sub": "system:serviceaccount:kube-system:external-dns"
+          "irsa.test.gaws.gigantic.io:sub": "system:serviceaccount:*:*external-dns*"
         }
       }
     }

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -72,7 +72,7 @@ var externalDnsRoleInfo = RoleInfo{
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
-        "StringEquals": {
+        "StringLike": {
           "irsa.test.gaws.gigantic.io:sub": "system:serviceaccount:*:*external-dns*"
         }
       }

--- a/pkg/iam/route53_template.go
+++ b/pkg/iam/route53_template.go
@@ -42,7 +42,7 @@ const externalDnsTrustIdentityPolicyIRSA = `{
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
-        "StringEquals": {
+        "StringLike": {
           "{{.CloudFrontDomain}}:sub": "system:serviceaccount:*:*{{.ServiceAccount}}*"
         }
       }
@@ -54,7 +54,7 @@ const externalDnsTrustIdentityPolicyIRSA = `{
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
-        "StringEquals": {
+        "StringLike": {
           "{{.AdditionalCloudFrontDomain}}:sub": "system:serviceaccount:*:*{{.ServiceAccount}}*"
         }
       }

--- a/pkg/iam/route53_template.go
+++ b/pkg/iam/route53_template.go
@@ -32,6 +32,38 @@ const trustIdentityPolicyIRSA = `{
 }
 `
 
+const externalDnsTrustIdentityPolicyIRSA = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:{{.AWSDomain}}:iam::{{.AccountID}}:oidc-provider/{{.CloudFrontDomain}}"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "{{.CloudFrontDomain}}:sub": "system:serviceaccount:*:*{{.ServiceAccount}}*"
+        }
+      }
+    }{{if .AdditionalCloudFrontDomain}},
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:{{.AWSDomain}}:iam::{{.AccountID}}:oidc-provider/{{.AdditionalCloudFrontDomain}}"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "{{.AdditionalCloudFrontDomain}}:sub": "system:serviceaccount:*:*{{.ServiceAccount}}*"
+        }
+      }
+    }
+    {{end}}
+  ]
+}
+`
+
 const route53RolePolicyTemplate = `{
   "Version": "2012-10-17",
   "Statement": [

--- a/pkg/iam/template.go
+++ b/pkg/iam/template.go
@@ -83,7 +83,7 @@ func getTrustPolicyTemplate(roleType string) string {
 	case NodesRole:
 		return ec2TrustIdentityPolicyTemplate
 	case Route53Role:
-		return trustIdentityPolicyIRSA
+		return externalDnsTrustIdentityPolicyIRSA
 	case KIAMRole:
 		return kiamTrustIdentityPolicy
 	case IRSARole:


### PR DESCRIPTION
…e to allow running multiple external-dns instances in the same cluster.

towards: https://github.com/giantswarm/roadmap/issues/3330