### PR TITLE
add-toleration-for-unitialized-nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add toleration for `node.cluster.x-k8s.io/uninitialized` taint.
+- Remove toleration for old `node-role.kubernetes.io/master` taint.
+
 ## [0.21.1] - 2024-04-11
 
 ### Fixed

--- a/helm/capa-iam-operator/templates/deployment.yaml
+++ b/helm/capa-iam-operator/templates/deployment.yaml
@@ -29,16 +29,12 @@ spec:
               - key: node-role.kubernetes.io/control-plane
                 operator: DoesNotExist
             weight: 10
-          - preference:
-              matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: DoesNotExist
-            weight: 10
       tolerations:
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
         key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
+        key: "node.cluster.x-k8s.io/uninitialized"
+        operator: "Exists"
       serviceAccountName: {{ include "resource.default.name"  . }}
       securityContext:
         runAsUser: {{ .Values.pod.user.id }}


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/30433

### Changed

- Add toleration for `node.cluster.x-k8s.io/uninitialized` taint.
- Remove toleration for old `node-role.kubernetes.io/master` taint.