### PR TITLE
Disable logger development mode to avoid panicking, use zap as logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Disable logger development mode to avoid panicking, use zap as logger
+
 ## [0.27.0] - 2024-07-11
 
 ### Fixed

--- a/controllers/awsmachinepool_controller_test.go
+++ b/controllers/awsmachinepool_controller_test.go
@@ -42,7 +42,7 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 	SetupNamespaceBeforeAfterEach(&namespace)
 
 	BeforeEach(func() {
-		logger := zap.New(zap.WriteTo(GinkgoWriter))
+		logger := zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true))
 		ctx = log.IntoContext(context.Background(), logger)
 
 		mockCtrl = gomock.NewController(GinkgoT())

--- a/controllers/awsmachinetemplate_controller_test.go
+++ b/controllers/awsmachinetemplate_controller_test.go
@@ -41,7 +41,7 @@ var _ = Describe("AWSMachineTemplateReconciler", func() {
 	SetupNamespaceBeforeAfterEach(&namespace)
 
 	BeforeEach(func() {
-		logger := zap.New(zap.WriteTo(GinkgoWriter))
+		logger := zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true))
 		ctx = log.IntoContext(context.Background(), logger)
 
 		mockCtrl = gomock.NewController(GinkgoT())

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	k8s.io/api v0.27.3
 	k8s.io/apimachinery v0.27.3
 	k8s.io/client-go v0.27.3
-	k8s.io/klog/v2 v2.100.1
 	k8s.io/kubectl v0.27.3
 	sigs.k8s.io/cluster-api v1.5.3
 	sigs.k8s.io/cluster-api-provider-aws/v2 v2.3.5
@@ -84,6 +83,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.27.3 // indirect
 	k8s.io/component-base v0.27.3 // indirect
+	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect
 	k8s.io/utils v0.0.0-20230220204549-a5ecb0141aa5 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/main.go
+++ b/main.go
@@ -28,7 +28,6 @@ import (
 	awsiam "github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	klogr "k8s.io/klog/v2/klogr"
 	eks "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/eks/api/v1beta2"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -79,12 +78,12 @@ func main() {
 	flag.BoolVar(&enableRoute53Role, "enable-route53-role", true,
 		"Enable creation and management of Route53 role for external-dns app.")
 	opts := zap.Options{
-		Development: true,
+		Development: false,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	ctrl.SetLogger(klogr.New())
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,


### PR DESCRIPTION
https://github.com/giantswarm/giantswarm/issues/31401

Dev mode in tests, but not in prod