### PR TITLE
Support new, plural `aws.giantswarm.io/irsa-trust-domains` annotation on the AWSCluster object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Support new, plural `aws.giantswarm.io/irsa-trust-domains` annotation on the AWSCluster object that centrally defines which service account issuer domains to use. The previous annotation is supported for backward compatibility.
+
 ## [0.27.1] - 2024-08-21
 
 ### Fixed

--- a/controllers/awsmachinetemplate_controller.go
+++ b/controllers/awsmachinetemplate_controller.go
@@ -265,9 +265,9 @@ func (r *AWSMachineTemplateReconciler) reconcileNormal(ctx context.Context, iamS
 
 			irsaDomain := key.IRSADomain(baseDomain, awsCluster.Spec.Region, accountID, clusterName)
 
-			oldIrsaDomain := key.GetAdditionalIrsaDomain(awsMachineTemplate)
+			irsaTrustDomains := key.GetIRSATrustDomains(awsMachineTemplate, awsCluster, irsaDomain)
 
-			err = iamService.ReconcileRolesForIRSA(accountID, irsaDomain, oldIrsaDomain)
+			err = iamService.ReconcileRolesForIRSA(accountID, irsaTrustDomains)
 			if err != nil {
 				return ctrl.Result{}, errors.WithStack(err)
 			}

--- a/controllers/awsmanagedcontrolplane_controller.go
+++ b/controllers/awsmanagedcontrolplane_controller.go
@@ -146,7 +146,7 @@ func (r *AWSManagedControlPlaneReconciler) Reconcile(ctx context.Context, req ct
 		}
 
 		iamService.SetPrincipalRoleARN(eksRoleARN)
-		err = iamService.ReconcileRolesForIRSA(accountID, eksOpenIdDomain, "")
+		err = iamService.ReconcileRolesForIRSA(accountID, []string{eksOpenIdDomain})
 		if err != nil {
 			return ctrl.Result{}, microerror.Mask(err)
 		}

--- a/pkg/iam/control_plane_template.go
+++ b/pkg/iam/control_plane_template.go
@@ -6,7 +6,7 @@ const ec2TrustIdentityPolicyTemplate = `{
     {
       "Effect": "Allow",
       "Principal": {
-        "Service": "{{.EC2ServiceDomain}}"
+        "Service": "{{ .EC2ServiceDomain }}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -36,7 +36,7 @@ const controlPlanePolicyTemplate = `{
     {
       "Condition": {
         "StringEquals": {
-          "autoscaling:ResourceTag/sigs.k8s.io/cluster-api-provider-aws/cluster/{{.ClusterName}}": "owned"
+          "autoscaling:ResourceTag/sigs.k8s.io/cluster-api-provider-aws/cluster/{{ .ClusterName }}": "owned"
         }
       },
       "Action": [

--- a/pkg/iam/kiam_template.go
+++ b/pkg/iam/kiam_template.go
@@ -6,7 +6,7 @@ const kiamTrustIdentityPolicy = `{
     {
       "Effect": "Allow",
       "Principal": {
-        "AWS": "{{.ControlPlaneRoleARN}}"
+        "AWS": "{{ .ControlPlaneRoleARN }}"
       },
       "Action": "sts:AssumeRole"
     }

--- a/pkg/iam/nodes_template.go
+++ b/pkg/iam/nodes_template.go
@@ -27,7 +27,7 @@ const nodesTemplate = `{
     {
       "Condition": {
         "StringEquals": {
-          "autoscaling:ResourceTag/sigs.k8s.io/cluster-api-provider-aws/cluster/{{.ClusterName}}": "owned"
+          "autoscaling:ResourceTag/sigs.k8s.io/cluster-api-provider-aws/cluster/{{ .ClusterName }}": "owned"
         }
       },
       "Action": [

--- a/pkg/iam/route53_template.go
+++ b/pkg/iam/route53_template.go
@@ -3,31 +3,21 @@ package iam
 const trustIdentityPolicyIRSA = `{
   "Version": "2012-10-17",
   "Statement": [
+    {{- range $index, $domain := .IRSATrustDomains }}
+    {{ if gt $index 0 }},{{ end -}}
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:{{.AWSDomain}}:iam::{{.AccountID}}:oidc-provider/{{.CloudFrontDomain}}"
+        "Federated": "arn:{{ $.AWSDomain }}:iam::{{ $.AccountID }}:oidc-provider/{{ $domain }}"
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
-          "{{.CloudFrontDomain}}:sub": "system:serviceaccount:{{.Namespace}}:{{.ServiceAccount}}"
-        }
-      }
-    }{{if .AdditionalCloudFrontDomain}},
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Federated": "arn:{{.AWSDomain}}:iam::{{.AccountID}}:oidc-provider/{{.AdditionalCloudFrontDomain}}"
-      },
-      "Action": "sts:AssumeRoleWithWebIdentity",
-      "Condition": {
-        "StringEquals": {
-          "{{.AdditionalCloudFrontDomain}}:sub": "system:serviceaccount:{{.Namespace}}:{{.ServiceAccount}}"
+          "{{ $domain }}:sub": "system:serviceaccount:{{ $.Namespace }}:{{ $.ServiceAccount }}"
         }
       }
     }
-    {{end}}
+    {{- end }}
   ]
 }
 `
@@ -35,31 +25,21 @@ const trustIdentityPolicyIRSA = `{
 const albControllerTrustIdentityPolicyIRSA = `{
   "Version": "2012-10-17",
   "Statement": [
+    {{- range $index, $domain := .IRSATrustDomains }}
+    {{ if gt $index 0 }},{{ end -}}
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:{{.AWSDomain}}:iam::{{.AccountID}}:oidc-provider/{{.CloudFrontDomain}}"
+        "Federated": "arn:{{ $.AWSDomain }}:iam::{{ $.AccountID }}:oidc-provider/{{ $domain }}"
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringLike": {
-          "{{.CloudFrontDomain}}:sub": "system:serviceaccount:*:{{.ServiceAccount}}"
-        }
-      }
-    }{{if .AdditionalCloudFrontDomain}},
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Federated": "arn:{{.AWSDomain}}:iam::{{.AccountID}}:oidc-provider/{{.AdditionalCloudFrontDomain}}"
-      },
-      "Action": "sts:AssumeRoleWithWebIdentity",
-      "Condition": {
-        "StringLike": {
-          "{{.AdditionalCloudFrontDomain}}:sub": "system:serviceaccount:*:{{.ServiceAccount}}"
+          "{{ $domain }}:sub": "system:serviceaccount:*:{{ $.ServiceAccount }}"
         }
       }
     }
-    {{end}}
+    {{- end }}
   ]
 }
 `
@@ -67,31 +47,21 @@ const albControllerTrustIdentityPolicyIRSA = `{
 const externalDnsTrustIdentityPolicyIRSA = `{
   "Version": "2012-10-17",
   "Statement": [
+    {{- range $index, $domain := .IRSATrustDomains }}
+    {{ if gt $index 0 }},{{ end -}}
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:{{.AWSDomain}}:iam::{{.AccountID}}:oidc-provider/{{.CloudFrontDomain}}"
+        "Federated": "arn:{{ $.AWSDomain }}:iam::{{ $.AccountID }}:oidc-provider/{{ $domain }}"
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringLike": {
-          "{{.CloudFrontDomain}}:sub": "system:serviceaccount:*:*{{.ServiceAccount}}*"
-        }
-      }
-    }{{if .AdditionalCloudFrontDomain}},
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Federated": "arn:{{.AWSDomain}}:iam::{{.AccountID}}:oidc-provider/{{.AdditionalCloudFrontDomain}}"
-      },
-      "Action": "sts:AssumeRoleWithWebIdentity",
-      "Condition": {
-        "StringLike": {
-          "{{.AdditionalCloudFrontDomain}}:sub": "system:serviceaccount:*:*{{.ServiceAccount}}*"
+          "{{ $domain }}:sub": "system:serviceaccount:*:*{{ $.ServiceAccount }}*"
         }
       }
     }
-    {{end}}
+    {{- end }}
   ]
 }
 `


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/31589

Together with https://github.com/giantswarm/cluster/pull/323 + https://github.com/giantswarm/cluster-aws/pull/814, this new, plural annotation makes it easier for us to consume the IRSA trust domains. It will be used _here_, and also in `aws-crossplane-cluster-config-operator` (upcoming PR).