### PR TITLE
Support reduced IAM permissions for instance profile of worker nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Dynamically calculate CAPI and CAPA versions from go cache, so that we use the right path when installing the CRDs during tests.
+- Support reduced IAM permissions for instance profile of worker nodes
 
 ## [0.28.0] - 2024-09-20
 

--- a/controllers/awsmachinepool_controller.go
+++ b/controllers/awsmachinepool_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	awsclientgo "github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
@@ -97,6 +98,7 @@ func (r *AWSMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	var iamService *iam.IAMService
 	{
 		c := iam.IAMServiceConfig{
+			ObjectLabels:     maps.Clone(awsMachinePool.GetLabels()),
 			AWSSession:       awsClientSession,
 			ClusterName:      clusterName,
 			MainRoleName:     awsMachinePool.Spec.AWSLaunchTemplate.IamInstanceProfile,

--- a/controllers/awsmachinepool_controller_test.go
+++ b/controllers/awsmachinepool_controller_test.go
@@ -94,7 +94,8 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 		err = k8sClient.Create(ctx, &capa.AWSCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
-					"cluster.x-k8s.io/cluster-name": "test-cluster",
+					"cluster.x-k8s.io/cluster-name":                                "test-cluster",
+					"alpha.aws.giantswarm.io/reduced-instance-permissions-workers": "true",
 				},
 				Name:      "my-awsc",
 				Namespace: namespace,

--- a/pkg/iam/template.go
+++ b/pkg/iam/template.go
@@ -6,6 +6,8 @@ import (
 	"text/template"
 )
 
+const AWSReducedInstanceProfileIAMPermissionsForWorkersLabel = "alpha.aws.giantswarm.io/reduced-instance-permissions-workers"
+
 func generatePolicyDocument(t string, params interface{}) (string, error) {
 	tmpl, err := template.New("policy").Parse(t)
 	if err != nil {
@@ -45,14 +47,21 @@ func isChinaRegion(region string) bool {
 	return strings.Contains(region, "cn-")
 }
 
-func getInlinePolicyTemplate(roleType string) string {
+func getInlinePolicyTemplate(roleType string, objectLabels map[string]string) string {
 	switch roleType {
 	case BastionRole:
 		return bastionPolicyTemplate
 	case ControlPlaneRole:
 		return controlPlanePolicyTemplate
 	case NodesRole:
-		return nodesTemplate
+		if _, ok := objectLabels[AWSReducedInstanceProfileIAMPermissionsForWorkersLabel]; ok {
+			// Reduce permissions to zero. All applications on worker nodes that want to reach the AWS API must use
+			// IRSA for credentials and must not fall back to the EC2 instance's IAM instance profile.
+			return ""
+		} else {
+			// Previous default
+			return nodesTemplate
+		}
 	case Route53Role:
 		return route53RolePolicyTemplate
 	case KIAMRole:

--- a/pkg/iam/template.go
+++ b/pkg/iam/template.go
@@ -54,7 +54,7 @@ func getInlinePolicyTemplate(roleType string, objectLabels map[string]string) st
 	case ControlPlaneRole:
 		return controlPlanePolicyTemplate
 	case NodesRole:
-		if _, ok := objectLabels[AWSReducedInstanceProfileIAMPermissionsForWorkersLabel]; ok {
+		if labelValue := objectLabels[AWSReducedInstanceProfileIAMPermissionsForWorkersLabel]; labelValue == "true" {
 			// Reduce permissions to zero. All applications on worker nodes that want to reach the AWS API must use
 			// IRSA for credentials and must not fall back to the EC2 instance's IAM instance profile.
 			return ""


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3795

Using a label allows us to control which releases use the reduced permission set. Currently, that means zero permissions (= delete IAM policy since it can't be empty). But if we should find out that something breaks, we can easily bring back permissions by changing the operator, not requiring changes to releases. Also, we can add a feature toggle to cluster-aws which just toggles the label.