### PR TITLE
Reintroduce ECR permissions for worker nodes since authentication is required at least for private ECR image repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Reintroduce ECR permissions for worker nodes since authentication is required at least for private ECR image repositories
+
 ## [0.29.0] - 2025-01-20
 
 ### Changed

--- a/pkg/iam/nodes_template.go
+++ b/pkg/iam/nodes_template.go
@@ -1,6 +1,26 @@
 package iam
 
-const nodesTemplate = `{
+const nodesReducedPermissionsTemplate = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:BatchGetImage",
+        "ecr:DescribeRepositories",
+        "ecr:GetAuthorizationToken",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:GetRepositoryPolicy",
+        "ecr:ListImages"
+      ],
+      "Resource": "*",
+      "Effect": "Allow"
+    }
+  ]
+}
+`
+
+const nodesFullPermissionsTemplate = `{
   "Version": "2012-10-17",
   "Statement": [
     {

--- a/pkg/iam/template.go
+++ b/pkg/iam/template.go
@@ -57,10 +57,10 @@ func getInlinePolicyTemplate(roleType string, objectLabels map[string]string) st
 		if labelValue := objectLabels[AWSReducedInstanceProfileIAMPermissionsForWorkersLabel]; labelValue == "true" {
 			// Reduce permissions to zero. All applications on worker nodes that want to reach the AWS API must use
 			// IRSA for credentials and must not fall back to the EC2 instance's IAM instance profile.
-			return ""
+			return nodesReducedPermissionsTemplate
 		} else {
 			// Previous default
-			return nodesTemplate
+			return nodesFullPermissionsTemplate
 		}
 	case Route53Role:
 		return route53RolePolicyTemplate


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3795, fix for being able to pull private ECR images