### PR TITLE
Reintroduce IAM permissions for Cilium ENI mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Reintroduce ECR permissions for worker nodes since authentication is required at least for private ECR image repositories
+- Reintroduce IAM permissions for Cilium ENI mode
 
 ## [0.29.0] - 2025-01-20
 

--- a/pkg/iam/iam.go
+++ b/pkg/iam/iam.go
@@ -89,6 +89,9 @@ func New(config IAMServiceConfig) (*IAMService, error) {
 	if !(config.RoleType == ControlPlaneRole || config.RoleType == NodesRole || config.RoleType == BastionRole || config.RoleType == IRSARole) {
 		return nil, fmt.Errorf("cannot create IAMService with invalid RoleType '%s'", config.RoleType)
 	}
+	if config.ObjectLabels == nil {
+		config.ObjectLabels = map[string]string{}
+	}
 	iamClient := config.IAMClientFactory(config.AWSSession, config.Region)
 	eksClient := eks.New(config.AWSSession, &aws.Config{Region: aws.String(config.Region)})
 
@@ -115,9 +118,11 @@ func (s *IAMService) ReconcileRole() error {
 	params := struct {
 		ClusterName      string
 		EC2ServiceDomain string
+		ObjectLabels     map[string]string
 	}{
 		ClusterName:      s.clusterName,
 		EC2ServiceDomain: ec2ServiceDomain(s.region),
+		ObjectLabels:     s.objectLabels,
 	}
 	err := s.reconcileRole(s.mainRoleName, s.roleType, params)
 	if err != nil {

--- a/pkg/iam/nodes_template.go
+++ b/pkg/iam/nodes_template.go
@@ -3,6 +3,28 @@ package iam
 const nodesReducedPermissionsTemplate = `{
   "Version": "2012-10-17",
   "Statement": [
+    {{- if eq (index .ObjectLabels "alpha.aws.giantswarm.io/ipam-mode") "eni" }}
+    {
+      "Action": [
+        "ec2:AssignPrivateIpAddresses",
+        "ec2:AttachNetworkInterface",
+        "ec2:CreateNetworkInterface",
+        "ec2:CreateTags",
+        "ec2:DeleteNetworkInterface",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceTypes",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeTags",
+        "ec2:DescribeVpcs",
+        "ec2:ModifyNetworkInterfaceAttribute",
+        "ec2:UnassignPrivateIpAddresses"
+      ],
+      "Resource": "*",
+      "Effect": "Allow"
+    },
+    {{- end }}
     {
       "Action": [
         "ecr:BatchCheckLayerAvailability",


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3795, fixes Cilium ENI mode

To avoid many if-else's and keep the permissions in one central template, I'm now really using the Go template functionality in order to determine if ENI mode stuff should be added or not.

I thought of limiting the permissions to certain resources, but since customers can also bring their own subnets+tags, it may be hard to do so while keeping everything working.