### PR TITLE
Put finalizers on infra machinepools instead of MachinePools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Put finalizers on infra machinepools instead of `MachinePools`.
+
 ## [1.0.0] - 2025-02-19
 
 ### Changed


### PR DESCRIPTION
It is sufficient to add the finalizer only to the infra machinepool (i.e AWSMachinePool). Since the infra machinepool is set as a dependent of the MachinePool (with its ownerReference including blockOwnerDeletion: true), Kubernetes will not complete deletion of the MachinePool until the infra machinepool is removed. This means that by holding up deletion on the infra machinepool (via its finalizer), you effectively prevent the MachinePool from being fully deleted before you’ve had a chance to clean up the IAM resources.

This is an example `AWSMachinePool` being owned by a `MachinePool`

```
apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
kind: AWSMachinePool
metadata:
  annotations:
    cluster-api-provider-aws: "true"
    meta.helm.sh/release-name: grizzly
    meta.helm.sh/release-namespace: org-giantswarm
    sigs.k8s.io/cluster-api-provider-aws-last-applied-tags: '{"giantswarm.io/cluster":"grizzly","giantswarm.io/installation":"grizzly","giantswarm.io/machinepool":"def00a","k8s.io/cluster-autoscaler/enabled":"true"}'
  creationTimestamp: "2024-03-05T14:12:21Z"
  finalizers:
  - awsmachinepool.infrastructure.cluster.x-k8s.io
  generation: 745
  labels:
    app: cluster-aws
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/version: 2.5.0
    application.giantswarm.io/team: phoenix
    cluster.x-k8s.io/cluster-name: grizzly
    cluster.x-k8s.io/watch-filter: capi
    giantswarm.io/cluster: grizzly
    giantswarm.io/machine-pool: grizzly-def00a
    giantswarm.io/organization: giantswarm
    helm.sh/chart: cluster-aws-2.5.0
    release.giantswarm.io/version: 29.5.0
  name: grizzly-def00a
  namespace: org-giantswarm
  ownerReferences:
  - apiVersion: cluster.x-k8s.io/v1beta1
    blockOwnerDeletion: true
    controller: true
    kind: MachinePool
    name: grizzly-def00a
    uid: 68e798db-0c09-4c73-989d-32ba31400482
  resourceVersion: "1040309495"
  uid: ba9b2c8a-fda1-407d-9c3f-1502c23fbd6f
```