### PR TITLE
Fix kmp spec reference

### DIFF
--- a/controllers/machinepool_controller.go
+++ b/controllers/machinepool_controller.go
@@ -98,7 +98,7 @@ func (r *MachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 	if !found {
 		// If we don't find it, let's try the `KarpenterMachinePool` field instead.
-		iamInstanceProfile, found, err = unstructured.NestedString(infraMachinePool.Object, "spec", "ec2NodeClass", "instanceProfile")
+		iamInstanceProfile, found, err = unstructured.NestedString(infraMachinePool.Object, "spec", "iamInstanceProfile")
 		if err != nil {
 			logger.Error(err, "error retrieving .spec.ec2NodeClass.instanceProfile", "infraMachinePool", machinePool.Spec.Template.Spec.InfrastructureRef.Name)
 			return ctrl.Result{}, errors.New("failed to get iamInstanceProfile")


### PR DESCRIPTION
https://github.com/giantswarm/aws-resolver-rules-operator/blob/main/helm/aws-resolver-rules-operator/templates/infrastructure.cluster.x-k8s.io_karpentermachinepools.yaml

The field changed place and this stops reconciliation