### PR TITLE
Add ec2:DescribeRouteTables permission to node template role for Cilium ENI mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add ec2:DescribeRouteTables permission to node template role for Cilium ENI mode.
+
 ## [1.4.0] - 2025-07-22
 
 ### Changed

--- a/pkg/iam/nodes_template.go
+++ b/pkg/iam/nodes_template.go
@@ -14,6 +14,7 @@ const nodesReducedPermissionsTemplate = `{
         "ec2:DescribeInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeNetworkInterfaces",
+		"ec2:DescribeRouteTables",
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

Towards https://github.com/giantswarm/giantswarm/issues/34195